### PR TITLE
Updated the main.tf for bigquery-datasets

### DIFF
--- a/modules/bigquery-dataset/main.tf
+++ b/modules/bigquery-dataset/main.tf
@@ -184,6 +184,7 @@ resource "google_bigquery_table" "default" {
 
 
 resource "google_bigquery_table" "views" {
+  depends_on    = [google_bigquery_table.default]
   for_each      = var.views
   project       = var.project_id
   dataset_id    = google_bigquery_dataset.default.dataset_id


### PR DESCRIPTION
Added the "depends_on" attribute for views to be created only after all the tables are created to avoid failure. 
Please check #145
This should help the user avoid the error "The table xxxxxx does not exist when creating a view.